### PR TITLE
Fix piechart layout

### DIFF
--- a/client/app/account/game/game.html
+++ b/client/app/account/game/game.html
@@ -140,9 +140,8 @@
 				<div class="panel-heading">
 					<h3 class="panel-title">Competing {{ _Outcomes_ }}</h3>
 				</div>
-				<div class="panel-body">
-		   	 	<div class="col-lg-5">
-
+				<div class="panel-body outcome-body">
+		   	 	<div class="col-lg-5 outcome-table">
 						<p>
 							<i>
 								Add a story and choose a bribe. The nicer the bribe:<br/> 
@@ -150,7 +149,6 @@
 								&bull; the more likely the story will be chosen
 							</i>
 						</p>
-						
 					 	<table class="table table-striped table-bordered">
 							<thead>
 								<tr>
@@ -166,7 +164,7 @@
 										<a href="#" tooltip="{{outcome.info}}" title="{{outcome.info}}" style='color: {{outcome.color }}'>{{outcome.name}}</a>
 									</td>
 									<td>
-			              <select id="outcomebribe" ng-model="outcome.bribe" ng-change="saveOutcome(outcome)" class="form-control">
+			              <select ng-model="outcome.bribe" ng-change="saveOutcome(outcome)" class="form-control outcomebribe">
 			                  <option value="">---Please select---</option>
 			                  <option value="{{bribe._id}}" ng-repeat="bribe in bribes">{{bribe.name}}</option>
 			              </select>
@@ -182,7 +180,7 @@
 						</table>
 					</div>
 			    <div class="col-lg-7">
-			      <div id="holder" style="display: block; position:relative !important;" ng-if="outcomes.length > 0"></div>
+			      <div id="holder" ng-if="outcomes.length > 0"></div>
 			    </div>
 		  	</div>
 				<div class="panel-footer">

--- a/client/app/account/game/game.scss
+++ b/client/app/account/game/game.scss
@@ -1,0 +1,21 @@
+@media (min-width: 1200px) {
+  .outcome-table {
+    min-height:450px;
+  }
+}
+
+@media (min-width:768px) and (max-width:1199px) {
+  .outcome-body {
+    min-height:750px;
+  }  
+  .outcome-table {
+    z-index:9999;
+  }
+}
+
+@media (max-width: 767px) {
+  .outcome-table {
+    z-index:9999;
+    min-height:1px;
+  }
+}

--- a/client/app/account/play/spinner/demo.css
+++ b/client/app/account/play/spinner/demo.css
@@ -7,11 +7,11 @@
 #holder {
     height: 600px;
     left: 50%;
-    margin: -120px 0 0 -320px;
+    margin: -100px 0 0 -320px;
     position: absolute;
     top: 50%;
     width: 640px;
-		overflow: hidden;
+	overflow: hidden;
 }
 #copy {
     bottom: 0;
@@ -53,7 +53,7 @@
 	}
 	
 	.panel-body {
-		min-height: 700px !important;
+		min-height: 500px;
 	}
 	
 }

--- a/client/app/app.scss
+++ b/client/app/app.scss
@@ -13,6 +13,7 @@ $fa-font-path: "/bower_components/font-awesome/fonts";
 
 // Component styles are injected through grunt
 // injector
+@import 'account/game/game.scss';
 @import 'account/login/login.scss';
 @import 'admin/admin.scss';
 @import 'landing/landing.scss';


### PR DESCRIPTION
In smaller screen, Piechart is on top of the story selection list which makes user unable to select bribe for each story.

Improved responsive layout.

![1](https://cloud.githubusercontent.com/assets/5624797/11610896/f563baa2-9c16-11e5-90fd-836fbdf6f2b0.PNG)
